### PR TITLE
Have CreateVMDisk return the created disk nam

### DIFF
--- a/virtual_machine_disk.go
+++ b/virtual_machine_disk.go
@@ -24,20 +24,21 @@ import (
 )
 
 // CreateVMDisk creates a new disk for the virtual machine.
-func (c *APIClient) CreateVMDisk(ctx context.Context, vmid int, node string, storage string, disk string, sizeBytes int64) error {
-	params := make(map[string]interface{})
+func (c *APIClient) CreateVMDisk(ctx context.Context, vmid int, node string, storage string, disk string, sizeBytes int64) (string, error) {
+	params := make(map[string]any)
 	params["vmid"] = vmid
 	params["node"] = node
 	params["storage"] = storage
 	params["filename"] = disk
 	params["size"] = fmt.Sprintf("%d", sizeBytes/1024)
+	name := ""
 
-	err := c.Client.Post(ctx, fmt.Sprintf("/nodes/%s/storage/%s/content", node, storage), params, nil)
+	err := c.Client.Post(ctx, fmt.Sprintf("/nodes/%s/storage/%s/content", node, storage), params, &name)
 	if err != nil {
-		return fmt.Errorf("unable to create disk for virtual machine: %w", err)
+		return name, fmt.Errorf("unable to create disk for virtual machine: %w", err)
 	}
 
-	return nil
+	return name, nil
 }
 
 // DeleteVMDisk deletes a disk from the virtual machine.


### PR DESCRIPTION
# Pull Request

## What? (description)

This change updates CreateVMDisk to return the disk name assigned by the Proxmox storage plugin after successful creation. The returned value represents the authoritative disk identifier and can be used directly by callers for subsequent operations or integrations.

## Why? (reasoning)

CreateVMDisk currently creates a disk successfully, but the caller has no reliable way to determine the final disk name assigned by the Proxmox storage plugin. Storage backends may alter or fully determine the resulting disk identifier, which makes it difficult for callers to correctly reference, track, or persist the created disk without additional API calls or assumptions.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
