### PR TITLE
fix: wait for stop task in DeleteVMByID before issuing destroy

### DIFF
--- a/virtual_machine_manage.go
+++ b/virtual_machine_manage.go
@@ -62,6 +62,13 @@ func (c *APIClient) StartVMByID(ctx context.Context, nodeName string, vmID int) 
 }
 
 // DeleteVMByID deletes a VM by its ID.
+//
+// If the VM is running it is stopped first. We wait for the stop task to
+// complete before issuing the delete so qemu-server has released the
+// /var/lock/qemu-server/lock-<vmid>.conf file; otherwise the destroy task
+// races against the still-running stop and fails with
+// "can't lock file '/var/lock/qemu-server/lock-<vmid>.conf' - got timeout",
+// leaving an orphan VM behind.
 func (c *APIClient) DeleteVMByID(ctx context.Context, nodeName string, vmID int) error {
 	vm := &proxmox.VirtualMachine{}
 	vm.New(c.Client, nodeName, vmID)
@@ -71,8 +78,19 @@ func (c *APIClient) DeleteVMByID(ctx context.Context, nodeName string, vmID int)
 	}
 
 	if vm.IsRunning() {
-		if _, err := vm.Stop(ctx); err != nil {
+		task, err := vm.Stop(ctx)
+		if err != nil {
 			return fmt.Errorf("failed to stop vm %d: %v", vmID, err)
+		}
+
+		if task != nil {
+			if err = task.WaitFor(ctx, 60); err != nil {
+				return fmt.Errorf("unable to stop vm %d: %w", vmID, err)
+			}
+
+			if task.IsFailed {
+				return fmt.Errorf("unable to stop vm %d: %s", vmID, task.ExitStatus)
+			}
 		}
 	}
 
@@ -80,8 +98,19 @@ func (c *APIClient) DeleteVMByID(ctx context.Context, nodeName string, vmID int)
 		c.flushResources("vm")
 	}()
 
-	if _, err := vm.Delete(ctx); err != nil {
+	task, err := vm.Delete(ctx)
+	if err != nil {
 		return fmt.Errorf("cannot delete vm with id %d: %w", vmID, err)
+	}
+
+	if task != nil {
+		if err = task.WaitFor(ctx, 60); err != nil {
+			return fmt.Errorf("unable to delete vm %d: %w", vmID, err)
+		}
+
+		if task.IsFailed {
+			return fmt.Errorf("unable to delete vm %d: %s", vmID, task.ExitStatus)
+		}
 	}
 
 	c.lastVMID.SetDefault(strconv.Itoa(vmID), struct{}{})


### PR DESCRIPTION
## Problem

`DeleteVMByID` stops a running VM and then immediately deletes it:

```go
if vm.IsRunning() {
    if _, err := vm.Stop(ctx); err != nil {
        return fmt.Errorf("failed to stop vm %d: %v", vmID, err)
    }
}

defer func() { c.flushResources("vm") }()

if _, err := vm.Delete(ctx); err != nil {
    return fmt.Errorf("cannot delete vm with id %d: %w", vmID, err)
}
```

Both `vm.Stop` and `vm.Delete` are asynchronous: they POST to the Proxmox API and return a task UPID. The current code discards the stop task with `_,` and never waits for it. While the stop task is still running, qemu-server holds `/var/lock/qemu-server/lock-<vmid>.conf`. The destroy task fires before that lock is released and fails after a 10-second wait with:

```
TASK ERROR: can't lock file '/var/lock/qemu-server/lock-<vmid>.conf' - got timeout
```

The HTTP `DELETE` call itself succeeds (the destroy task was accepted into the queue), so `vm.Delete(ctx)` returns no error and `DeleteVMByID` returns `nil`. The caller has no way to learn that the destroy task subsequently failed, and the VM is left running on the Proxmox host.

This was observed in the wild via `karpenter-provider-proxmox`, which calls `DeleteVMByID` from its node-disruption path. A `nil` return is treated as a successful destroy, so karpenter removes the `NodeClaim`. The VM that backed it stays around with no Kubernetes reference, accumulating in Proxmox over time.

A real Proxmox task entry for one such failure:

```
Task type:   qmdestroy
Status:      stopped: can't lock file '/var/lock/qemu-server/lock-20063.conf' - got timeout
Duration:    10s
User name:   kubernetes@pve!karpenter (API Token)
```

## Fix

Wait for the stop task to complete (and check its exit status) before issuing the delete. This mirrors the pattern already used by `StartVMByID` in this file. While here, also wait for the destroy task itself so that a `nil` return from `DeleteVMByID` reliably means the VM is gone — that's the contract callers expect, and it removes the second silent-failure surface (the destroy queue could fail for other reasons too, e.g. a storage backend hiccup).

## Verification

- `go build ./...` and `go vet ./...` clean.
- `go test ./...` passes.
- Manually traced the call path that surfaces this in karpenter-provider-proxmox v0.11.0 (`pkg/providers/instance/instance_utils.go::instanceDelete` → `pool.DeleteVMByIDInRegion` → `DeleteVMByID`); the panic-free `nil` return after a failed `qmdestroy` task is what produces the orphan VMs.