### PR TITLE
fix: detect boot disk dynamically in CloneVM instead of hardcoding scsi0

### DIFF
--- a/virtual_machine_manage.go
+++ b/virtual_machine_manage.go
@@ -294,9 +294,14 @@ func (c *APIClient) CloneVM(ctx context.Context, templateID int, options VMClone
 		return newid, fmt.Errorf("failed to get config of vm %d: %v", newid, err)
 	}
 
-	// FIXME: remove hardcoded disk name
-	if _, err = vm.ResizeDisk(ctx, "scsi0", options.DiskSize); err != nil {
-		return newid, fmt.Errorf("failed to resize disk for vm %d: %v", newid, err)
+	if options.DiskSize != "" {
+		bootDisk := detectBootDisk(vm.VirtualMachineConfig)
+		if bootDisk == "" {
+			return newid, fmt.Errorf("failed to detect boot disk for vm %d", newid)
+		}
+		if _, err = vm.ResizeDisk(ctx, bootDisk, options.DiskSize); err != nil {
+			return newid, fmt.Errorf("failed to resize disk %s for vm %d: %v", bootDisk, newid, err)
+		}
 	}
 
 	var vmOptions []proxmox.VirtualMachineOption

--- a/virtual_machine_utils.go
+++ b/virtual_machine_utils.go
@@ -180,3 +180,24 @@ func getVMOptionsToApply(current *proxmox.VirtualMachineConfig, desired map[stri
 
 	return vmOptions
 }
+
+// detectBootDisk returns the name of the first available boot disk from the VM config.
+// It checks virtio, scsi, sata, and ide buses in order of preference.
+func detectBootDisk(cfg *proxmox.VirtualMachineConfig) string {
+	if cfg == nil {
+		return ""
+	}
+	if cfg.VirtIO0 != "" {
+		return "virtio0"
+	}
+	if cfg.SCSI0 != "" {
+		return "scsi0"
+	}
+	if cfg.SATA0 != "" {
+		return "sata0"
+	}
+	if cfg.IDE0 != "" {
+		return "ide0"
+	}
+	return ""
+}


### PR DESCRIPTION
## Problem

`CloneVM` hardcoded `scsi0` as the disk name when calling `ResizeDisk` after cloning. This silently fails for VMs that use `virtio`, `sata`, or `ide` buses, leaving the disk at the template's original size instead of the requested `DiskSize`.

This was observed with `karpenter-provider-proxmox` v0.11.0: VMs were consistently provisioned with the template's original 3G disk regardless of the `bootDevice.size` set in the `ProxmoxNodeClass`.

## Fix

- Added `detectBootDisk()` that inspects the cloned VM config and returns the first available boot disk in preference order: `virtio0` → `scsi0` → `sata0` → `ide0`
- Guard the resize call so it is skipped when `DiskSize` is empty

## Testing

**Environment:**
- Proxmox VE: 8.2.2
- Kubernetes: v1.36.1
- karpenter-provider-proxmox: v0.11.0
- VM template: Debian 13 cloud-image using `virtio0` as boot disk (3G)
- Target disk size: 30G via `bootDevice.size` in `ProxmoxNodeClass`
- Storage: LVM (`HD3`)

**Before fix:** VMs cloned by Karpenter had `virtio0: HD3:vm-XXXXX-disk-0,size=3G` — `ResizeDisk` was called on `scsi0` which does not exist, leaving the disk unchanged.

**After fix:** VMs are correctly provisioned with the requested size — `virtio0: HD3:vm-XXXXX-disk-0,size=33G` (max between `bootDevice.size=30G` and the instance type StorageEphemeral).