### PR TITLE
feat: add ha rules list api

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -35,6 +35,17 @@ func (c *APIClient) GetHAGroupList(ctx context.Context) (groups []*HAGroup, err 
 	return groups, nil
 }
 
+// GetHARuleList retrieves the list of HA rules in the cluster.
+// HA rules replace HA groups since Proxmox VE 9.
+func (c *APIClient) GetHARuleList(ctx context.Context) (rules []*HARule, err error) {
+	err = c.Get(ctx, "/cluster/ha/rules", &rules)
+	if nil != err {
+		return nil, err
+	}
+
+	return rules, nil
+}
+
 func (c *APIClient) getResources(ctx context.Context, name string) (proxmox.ClusterResources, error) {
 	resources := proxmox.ClusterResources{}
 

--- a/types.go
+++ b/types.go
@@ -191,6 +191,19 @@ type HAGroup struct {
 	Type       string             `json:"type,omitempty"`
 }
 
+// HARule represents a High Availability rule configuration.
+// HA rules replace HA groups since Proxmox VE 9, existing groups are
+// migrated to rules of type 'node-affinity' automatically.
+type HARule struct {
+	Rule      string             `json:"rule"`
+	Type      string             `json:"type"`
+	Nodes     string             `json:"nodes,omitempty"`
+	Resources string             `json:"resources,omitempty"`
+	Comment   string             `json:"comment,omitempty"`
+	Disable   *proxmox.IntOrBool `json:"disable,omitempty"`
+	Strict    *proxmox.IntOrBool `json:"strict,omitempty"`
+}
+
 // NewIntOrBool creates a new IntOrBool pointer from a boolean value.
 func NewIntOrBool(b bool) *proxmox.IntOrBool {
 	res := proxmox.IntOrBool(b)


### PR DESCRIPTION
## What? (description)

Adds an `HARule` type and a `GetHARuleList` method reading the `/cluster/ha/rules` endpoint (Proxmox VE 9+).

## Why? (reasoning)

Proxmox VE 9 migrated HA groups to HA rules — the old `/cluster/ha/groups` endpoint fails there with `cannot index groups: ha groups have been migrated to rules` (500). This method lets consumers fall back to node affinity rules, which keep the same `node[:priority]` list format that groups had. On PVE 9 the rules index also migrates legacy group definitions server-side, so rule names match old group names.

Companion PR for the CCM (fixes sergelogvinov/proxmox-cloud-controller-manager#266) follows.

- Field schema verified against `pve-ha-manager` sources (`PVE::API2::HA::Rules`, `PVE::HA::Rules::NodeAffinity`).
- `make lint` and `go test -tags=unit` pass.
