### PR TITLE
fix: config pair parsing when value contains '='

### DIFF
--- a/types.go
+++ b/types.go
@@ -312,7 +312,7 @@ func unmarshal(s string, v any) error {
 
 	pairs := strings.Split(s, ",")
 	for _, p := range pairs {
-		v := strings.Split(strings.TrimSpace(p), "=")
+		v := strings.SplitN(strings.TrimSpace(p), "=", 2)
 
 		if len(v) == 2 {
 			for i := range psCount {

--- a/types_test.go
+++ b/types_test.go
@@ -265,3 +265,49 @@ func TestVMNUMA_ToString(t *testing.T) {
 		})
 	}
 }
+
+func TestVMSMBIOS_UnmarshalString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		template string
+		smbios   goproxmox.VMSMBIOS
+	}{
+		{
+			name:     "empty",
+			template: "",
+			smbios:   goproxmox.VMSMBIOS{},
+		},
+		{
+			name:     "plain values",
+			template: "uuid=9a9adf18-42da-4f0e-8003-afab51eab53e,manufacturer=proxmox",
+			smbios: goproxmox.VMSMBIOS{
+				Manufacturer: "proxmox",
+				UUID:         "9a9adf18-42da-4f0e-8003-afab51eab53e",
+			},
+		},
+		{
+			name:     "base64 values with padding",
+			template: "base64=1,serial=aD1ub2RlLTE7aT0yMDAwNQ==,sku=czEuNFZDUFUtMTZHQg==,uuid=9a9adf18-42da-4f0e-8003-afab51eab53e",
+			smbios: goproxmox.VMSMBIOS{
+				Base64: goproxmox.NewIntOrBool(true),
+				Serial: "aD1ub2RlLTE7aT0yMDAwNQ==",
+				SKU:    "czEuNFZDUFUtMTZHQg==",
+				UUID:   "9a9adf18-42da-4f0e-8003-afab51eab53e",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			res := goproxmox.VMSMBIOS{}
+
+			err := res.UnmarshalString(tt.template)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.smbios, res)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`unmarshal()` splits each `key=value` pair with `strings.Split(p, "=")` and only accepts the result when it has exactly two parts. Any value that itself contains `=` produces more parts and the pair is **silently dropped**.

This breaks base64-encoded `smbios1` fields whenever the encoded value has padding, which is the common case — e.g. a VM created by karpenter-provider-proxmox:

```
smbios1: base64=1,serial=...,sku=czEuNFZDUFUtMTZHQg==,uuid=...
```

`sku=czEuNFZDUFUtMTZHQg==` splits into 4 parts, the field is skipped, and `GetVMSKU()` returns an empty string. Downstream, proxmox-cloud-controller-manager then falls back to the generated `<n>VCPU-<n>GB` instance-type name instead of the SKU stamped by Karpenter (`s1.4VCPU-16GB`), so the node's `node.kubernetes.io/instance-type` label never matches the Karpenter instance-type catalog and every such node is reported `Unconsolidatable: Instance Type "4VCPU-16GB" not found` — disabling consolidation fleet-wide.

## Fix

Use `strings.SplitN(..., "=", 2)` so the first `=` separates key from value and the remainder (including any `=` padding) is preserved as the value.

## Testing

Added `TestVMSMBIOS_UnmarshalString` incl. a case with base64-padded `serial`/`sku` values taken from a real Karpenter-managed VM. The new case fails on the old parser and passes with the fix; `go test ./...` is green.